### PR TITLE
fix: socket return 403

### DIFF
--- a/socketio-client/src/client.py
+++ b/socketio-client/src/client.py
@@ -33,7 +33,7 @@ def main():
                              't': int(time.time()),
                              'projectId': project_id
                          },
-                         headers={'Cookie': cookie})
+                         headers={'Cookie': cookie, 'referer': f"{BASE_URL}/project/{project_id}"})
 
     socket_io.on('connect', lambda: None)
     socket_io.wait_for_callbacks()


### PR DESCRIPTION
When pushing, an error occurred stating `project_info` could not be retrieved.

The issue was traced to a socket connection returning a 403 error; adding a `Referer` header resolved the problem.